### PR TITLE
update node to version 10 to fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - '8'
+  - '10'
 script: node_modules/.bin/intern


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Travis build is currently failing:
https://travis-ci.org/github/Esri/arcgis-webpack-plugin/builds/737830166

This PR update node version to be used to run Travis test. Indeed, the error is coming from p-limit library which requires node >=10.


https://github.com/sindresorhus/p-limit/blob/b702cc1aa737ae834b4deaf87a537812d8d5418f/package.json#L14

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on GitLab CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.