### PR TITLE
Use value of "assetsDir" variable during asset copy

### DIFF
--- a/lib/requiredPlugins.js
+++ b/lib/requiredPlugins.js
@@ -60,7 +60,7 @@ module.exports = function requiredPlugins(locales = [], copyAssets = true, asset
           {
             context: "node_modules",
             from: `${jsapi}/assets`,
-            to: "assets",
+            to: assetsDir,
             globOptions: {
               // ignore the webscene spec folder, sass files,
               // and any locales not need for deployment


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fix addresses a regression introduced in commit Esri@7aadbb1 that clobbered the assetsDir variable being used.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Esri/arcgis-webpack-plugin/issues/114

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested change locally which correctly copied the assets to the directory specified by assetsDir

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.