### PR TITLE
Rename SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 [travis-img]: https://img.shields.io/travis/Esri/arcgis-webpack-plugin/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/Esri/arcgis-webpack-plugin
 
-Helper plugin for building ArcGIS API for JavaScript applications with webpack to copy assets locally.
+Helper plugin for building ArcGIS Maps SDK for JavaScript applications with webpack to copy assets locally.
 
-**This version of the plugin is for 4.18 or greater of the [ArcGIS API for JavaScript](https://developers.arcgis.com/javascript/).**
+**This version of the plugin is for 4.18 or greater of the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/).**
 
 For version 4.17 and lower, please see [this documentation here](https://github.com/Esri/arcgis-webpack-plugin/blob/96c60c8d469e4976d1b62ec30b4c9838e4d74480/README.md).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcgis/webpack-plugin",
   "version": "4.22.0",
-  "description": "Webpack plugin to load ArcGIS API for JavaScript into a Webpack application",
+  "description": "Webpack plugin to load ArcGIS Maps SDK for JavaScript into a Webpack application",
   "main": "index.js",
   "engines": {
     "node": ">=8.9.3"


### PR DESCRIPTION
This PR replaces all instances of the old naming convention with the new name. It roughly follows a convention of using the full name once per section followed by just using shorthand "SDK". The plan is to merge this change on or before Dec 14.

For more information see the [Introducing the ArcGIS Map SDKs](https://www.esri.com/arcgis-blog/products/developers/announcements/introducing-the-arcgis-maps-sdks/) blog post. 

Items of note:
* This PR does not create a new version of the plugin.